### PR TITLE
Fix panic in parse_text_impl when parsing a multi-byte string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,10 +1196,8 @@ impl<'a> Tokenizer<'a> {
         // https://www.w3.org/TR/xml/#syntax
         //
         // Search for `>` first, since it's a bit faster than looking for `]]>`.
-        if let Some(position) = text.as_str().find('>') {
-            if text.as_str()[position.saturating_sub(2)..].starts_with("]]>") {
-                return Err(StreamError::InvalidCharacterData);
-            }
+        if text.as_str().contains('>') && text.as_str().contains("]]>") {
+            return Err(StreamError::InvalidCharacterData);
         }
 
         Ok(Token::Text { text })

--- a/tests/integration/text.rs
+++ b/tests/integration/text.rs
@@ -65,6 +65,15 @@ test!(
 );
 
 test!(
+    text_08,
+    "<p>å ></p>",
+    Token::ElementStart("", "p", 0..2),
+    Token::ElementEnd(ElementEnd::Open, 2..3),
+    Token::Text("å >", 3..7),
+    Token::ElementEnd(ElementEnd::Close("", "p"), 7..11)
+);
+
+test!(
     text_err_01,
     "<p>]]></p>",
     Token::ElementStart("", "p", 0..2),


### PR DESCRIPTION
`parse_text_impl` causes a crash if a Text node contains a multi-byte character before a '>' because it slices inside the character.

Here's example code that causes a panic:
```rs
fn main() {
    let text = r#"<p>å ></p>"#;

    for token in htmlparser::Tokenizer::from(text) {
        println!("{:?}", token);
    }
}
```
<details>
<summary>Example output</summary>

This is the output and stack trace of the example.
```
Ok(ElementStart { prefix: StrSpan("" 0..0), local: StrSpan("p" 1..2), span: StrSpan("<p" 0..2) })
Ok(ElementEnd { end: Open, span: StrSpan(">" 2..3) })

thread 'main' panicked at /home/jstalnac/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/htmlparser-0.2.1/src/lib.rs:1200:29:
byte index 1 is not a char boundary; it is inside 'å' (bytes 0..2) of `å >`
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:75:14
   2: core::str::slice_error_fail_rt
   3: core::str::slice_error_fail
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/str/mod.rs:68:5
   4: core::str::traits::<impl core::slice::index::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index
             at /home/jstalnac/.local/share/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/str/traits.rs:537:21
   5: core::str::traits::<impl core::ops::index::Index<I> for str>::index
             at /home/jstalnac/.local/share/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/str/traits.rs:60:9
   6: htmlparser::Tokenizer::parse_text_impl
             at /home/jstalnac/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/htmlparser-0.2.1/src/lib.rs:1200:29
   7: htmlparser::Tokenizer::parse_text
             at /home/jstalnac/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/htmlparser-0.2.1/src/lib.rs:1189:21
   8: htmlparser::Tokenizer::parse_next_impl
             at /home/jstalnac/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/htmlparser-0.2.1/src/lib.rs:640:35
   9: <htmlparser::Tokenizer as core::iter::traits::iterator::Iterator>::next
             at /home/jstalnac/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/htmlparser-0.2.1/src/lib.rs:1221:17
  10: htmlparser_crash::main
             at ./main.rs:4:18
  11: core::ops::function::FnOnce::call_once
             at /home/jstalnac/.local/share/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
</details

This is the crashing code:
```rs
fn parse_text_impl(s: &mut Stream<'a>) -> StreamResult<Token<'a>> {
    let text = s.consume_chars(|_, c| c != '<')?;

    // According to the spec, `]]>` must not appear inside a Text node.
    // https://www.w3.org/TR/xml/#syntax
    //
    // Search for `>` first, since it's a bit faster than looking for `]]>`.
    if let Some(position) = text.as_str().find('>') {
        if text.as_str()[position.saturating_sub(2)..].starts_with("]]>") { // Crashes here
            return Err(StreamError::InvalidCharacterData);
        }
    }

    Ok(Token::Text { text })
}
```

`å` is two bytes as UTF-8 (`c3 a5`) so, in the example, when `parse_text_impl` slices the string to check for `]]>` it takes the space and the second byte `a5` from `å`. The `å` character becomes malformed so the program panics.

After my fix the contents of the paragraph tag would be parsed as `å >` (I added a test for it as well). I hope this is correct according to the spec.

This issue was in xmlparser as well (https://github.com/RazrFalcon/xmlparser/issues/31) so I just copied the fix they made.